### PR TITLE
ESDN: add alternative title and make collection mapping change

### DIFF
--- a/heidrun/esdn_mods.rb
+++ b/heidrun/esdn_mods.rb
@@ -24,12 +24,16 @@ Krikri::Mapper.define(:esdn_mods, :parser => Krikri::ModsParser) do
   end
 
   sourceResource :class => DPLA::MAP::SourceResource do
+    alternative record.field('mods:titleInfo')
+                      .match_attribute(:type, 'alternative')
+                      .field('mods:title')
+
     ##
-    # TODO: Crosswalk says to take collection from OAI set name/description,
-    # but we need to be able harvest set titles and populate them somewhere.
-    # This will just pull back the setSpec code for now.
+    # TODO: implement collection/set harvester and enrichment to complete
+    # the metadata required for collections. This just grabs the set's
+    # identifier from the OAI-PMH setSpec in the record header.
     collection :class => DPLA::MAP::Collection,
-               :each => header.field('xmlns:set_spec'),
+               :each => header.field('xmlns:setSpec'),
                :as => :coll do
       title coll
     end
@@ -96,7 +100,11 @@ Krikri::Mapper.define(:esdn_mods, :parser => Krikri::ModsParser) do
       providedLabel subject
     end
 
-    title record.field('mods:titleInfo', 'mods:title')
+    # Note: this rejects all mods:titleInfo elements where the @type
+    # attribute is present. Discussed w/ Gretchen and Tom on 5/26/15. 
+    title record.field('mods:titleInfo')
+                .reject { |t| t.attribute? :type }
+                .field('mods:title')
 
     # Selecting DCMIType-only values will be handled in enrichment
     dctype record.field('mods:typeOfResource')


### PR DESCRIPTION
- Add a mapping to `dcterms:alternative`.
  - ~~Note: Should `dcterms:title` mapping be changed to not include those titles that are mapped to `dcterms:alternative`? (cc @guegueng)~~ - resolved by 5fa6445
- Change the collection mapping to use the OAI-PMH `setSpec` element. (ESDN previously used the similarly named but non-spec-defined `set_spec` element.)
