### PR TITLE
Do not merge: feedback on genre changes

### DIFF
--- a/heidrun/mapping_tools.rb
+++ b/heidrun/mapping_tools.rb
@@ -46,7 +46,7 @@ module MappingTools
 
     def assign_manuscript(genres, opts)
       if manu_lang_material?(opts[:leader])
-        genres << 'manuscript'
+        genres << 'Manuscript'
         true
       else
         false
@@ -68,7 +68,7 @@ module MappingTools
         if slide?(opts[:cf_007]) || transparency?(opts[:cf_007])
           genres << 'Photograph / Pictorial Works'
           true
-        elsif film_video? opts[:cf_007]
+        elsif film_video?(opts[:cf_007])
           genres << 'Film / Video'
           true
         else

--- a/heidrun/mapping_tools.rb
+++ b/heidrun/mapping_tools.rb
@@ -1,0 +1,190 @@
+module MappingTools
+
+  module MARC
+    module_function
+
+    def genre(opts)
+      genres = []
+      args = [genres, opts]
+      assign_language(*args) || assign_musical_score(*args) ||
+        assign_manuscript(*args) || assign_maps(*args) ||
+        assign_projected(*args) || assign_two_d(*args) ||
+        assign_nonmusical_sound(*args) || assign_musical_sound(*args)
+      genres << 'Government Document' if government_document?(opts[:cf_008])
+      genres
+    end
+
+    def assign_language(genres, opts)
+      if language_material?(opts[:leader])
+        if monograph?(opts[:leader])
+          genres << 'Book'
+        elsif serial?(opts[:leader])
+          if newspapers?(opts[:cf_008])
+            genres << 'Newspapers'
+          else
+            genres << 'Serial'
+          end
+        elsif mono_component_part?(opts[:leader])
+          genres << 'Book'
+        else
+          genres << 'Serial'
+        end
+        true
+      else
+        false
+      end
+    end
+
+    def assign_musical_score(genres, opts)
+      if notated_music?(opts[:leader]) || manu_notated_music?(opts[:leader])
+        genres << 'Musical Score'
+        true
+      else
+        false
+      end
+    end
+
+    def assign_manuscript(genres, opts)
+      if manu_lang_material?(opts[:leader])
+        genres << 'manuscript'
+        true
+      else
+        false
+      end
+    end
+
+    def assign_maps(genres, opts)
+      if cart_material?(opts[:leader]) || manu_cart_material?(opts[:leader])
+        genres << 'Maps'
+        true
+      else
+        false
+      end
+    end
+
+    # projected media
+    def assign_projected(genres, opts)
+      if projected_medium?(opts[:leader])
+        if slide?(opts[:cf_007]) || transparency?(opts[:cf_007])
+          genres << 'Photograph / Pictorial Works'
+          true
+        elsif film_video? opts[:cf_007]
+          genres << 'Film / Video'
+          true
+        else
+          false
+        end
+      else
+        false
+      end
+    end
+
+    # two-dimensional nonprojectable graphic
+    def assign_two_d(genres, opts)
+      if two_d_nonproj_graphic?(opts[:leader])
+        genres << 'Photograph / Pictorial Works'
+        true
+      else
+        false
+      end
+    end
+
+    def assign_nonmusical_sound(genres, opts)
+      if nonmusical_sound?(opts[:leader])
+        genres << 'Nonmusic Audio'
+        true
+      else
+        false
+      end
+    end
+
+    def assign_musical_sound(genres, opts)
+      if musical_sound?(opts[:leader])
+        genres << 'Music'
+        true
+      else
+        false
+      end
+    end
+
+    def language_material?(s)
+      s[6] == 'a'
+    end
+
+    def monograph?(s)
+      s[7] == 'm'
+    end
+
+    def newspapers?(s)
+      s[21] == 'n'
+    end
+
+    def serial?(s)
+      s[7] == 's'
+    end
+
+    # monographic component part
+    def mono_component_part?(s)
+      s[7] == 'a'
+    end
+
+    def notated_music?(s)
+      s[6] == 'c'
+    end
+
+    # manuscript notated music
+    def manu_notated_music?(s)
+      s[6] == 'd'
+    end
+
+    # manuscript language material
+    def manu_lang_material?(s)
+      s[6] == 't'
+    end
+
+    # cartographic material
+    def cart_material?(s)
+      s[6] == 'e'
+    end
+
+    # manuscript cartographic material
+    def manu_cart_material?(s)
+      s[6] == 'f'
+    end
+
+    def projected_medium?(s)
+      s[6] == 'g'
+    end
+
+    def slide?(s)
+      s[1] == 's'
+    end
+
+    def transparency?(s)
+      s[1] == 't'
+    end
+
+    def film_video?(s)
+      %w(c d f o).include?(s[1])
+    end
+
+    # two-dimensional non-projectable graphic
+    def two_d_nonproj_graphic?(s)
+      s[6] == 'k'
+    end
+
+    # nonmusical sound recording
+    def nonmusical_sound?(s)
+      s[6] == 'i'
+    end
+
+    # musical sound recording
+    def musical_sound?(s)
+      s[6] == 'j'
+    end
+
+    def government_document?(s)
+      %w(a c f i l m o s).include?(s[28])
+    end
+  end
+end

--- a/heidrun/ufl_marc.rb
+++ b/heidrun/ufl_marc.rb
@@ -1,3 +1,9 @@
+
+def caribbean?(parser_value)
+  parser_value.value.include?('Digital Library of the Caribbean')
+end
+
+
 Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MARCXMLParser) do
 
   provider :class => DPLA::MAP::Agent do
@@ -12,19 +18,14 @@ Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MARCXMLParser) do
     providedLabel dataP.field('marc:subfield').match_attribute(:code, 'a')
   end
 
-  # Not sure how to limit this to only those fields with the value "Digital
-  # Library of the Caribbean." (the period is included in the MARC record)
-  # Guessing here based on something in the ESDN map.  --GG
   intermediateProvider :class => DPLA::MAP::Agent,
                        :each => record.field('marc:datafield')
-                                      .match_attribute(:tag, '830'),
-                       :as => :interP do
-    # FIXME:  Produces multiple providedLabels where the value is 'false'
-    providedLabel interP.field('marc:subfield')
-                        .match_attribute(:code, 'a')
-                        .select do |code_a|
-                          code_a.include?('Digital Library of the Caribbean.')
-                        end
+                                      .match_attribute(:tag, '830')
+                                      .field('marc:subfield')
+                                      .match_attribute(:code, 'a')
+                                      .select { |a| caribbean?(a) },
+                       :as => :ip do
+    providedLabel ip
   end
   
   isShownAt :class => DPLA::MAP::WebResource,

--- a/heidrun/ufl_marc.rb
+++ b/heidrun/ufl_marc.rb
@@ -97,7 +97,11 @@ Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MARCXMLParser) do
       providedLabel date.field('marc:subfield').match_attribute(:code, 'c')
     end
 
-    #description 
+    # description
+    #   5XX; not 538, 535, 533, 510
+    description record.field('marc:datafield')
+                      .select { |df| df.tag[/^5(?!10|33|35|38)[0-9]{2}/] }
+                      .field('marc:subfield')
 
     extent record.field('marc:datafield')
             .match_attribute(:tag) { |tag| tag == '300' || tag == '340' }

--- a/heidrun/ufl_marc.rb
+++ b/heidrun/ufl_marc.rb
@@ -3,6 +3,39 @@ def caribbean?(parser_value)
   parser_value.value.include?('Digital Library of the Caribbean')
 end
 
+# FIXME:  This is the original mapping that Gretchen was trying to express:
+# It's clear what needs to be mapped, but I can not figure out how to go about
+# it given the restraints of the DSL and my inability to debug the code below
+# and on line 106. --MB
+#
+# extent record.fields(
+#             [('marc:datafield').match_attribute(:tag, '300')
+#                                .field('marc:subfield')
+#                                .match_attribute(:code, 'a')],
+#             [('marc:datafield').match_attribute(:tag, '300')
+#                                .field('marc:subfield')
+#                                .match_attribute(:code, 'c')],
+#             [('marc:datafield').match_attribute(:tag, '340')
+#                                .field('marc:subfield')
+#                                .match_attribute(:code, 'b')]
+# )
+def extent_val(parser_value)
+  return nil unless parser_value.node.attributes.include?('tag')
+  if parser_value.node.attributes['tag'].value == '300'
+    parser_value.node.children.each do |c|
+      next unless c.attributes.include?('code')
+      if ['a', 'c'].include?(c.attributes['code'].value)
+        return c.text
+      end
+    end
+  elsif parser_value.node.attributes['tag'].value == '340'
+    parser_value.node.children.each do |c|
+      next unless c.attributes.include?('code')
+      return c.text if c.attributes['code'].value == 'b'
+    end
+  end
+end
+
 
 Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MARCXMLParser) do
 
@@ -69,14 +102,8 @@ Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MARCXMLParser) do
 
     #description 
 
-    # FIXME:
-    # extent record.fields([('marc:datafield')
-    #               .match_attribute(:tag, '300')
-    #               .field('marc:subfield').match_attribute(:code, 'a')],
-    #               [('marc:datafield').match_attribute(:tag, '300')
-    #               .field('marc:subfield').match_attribute(:code, 'c')],
-    #               [('marc:datafield').match_attribute(:tag, '340')
-    #               .field('marc:subfield').match_attribute(:code, 'b')])
+    # FIXME:  does not work.
+    extent record.field('marc:datafield').map { |df| extent_val(df) }
 
     #dcformat 
     

--- a/heidrun/ufl_marc.rb
+++ b/heidrun/ufl_marc.rb
@@ -1,0 +1,109 @@
+Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MarcParser) do
+
+  provider :class => DPLA::MAP::Agent do
+    uri 'http://dp.la/api/contributor/ufl'
+    label 'University of Florida Libraries'
+  end
+
+  dataProvider :class => DPLA::MAP::Agent do
+               :each => record.field('marc:datafield')
+                              .match_attribute(:tag, '535')
+               :as => :dataP do
+    providedLabel dataP.field('marc:subfield').match_attribute(:code, 'a')
+  end
+
+  # Not sure how to limit this to only those fields with the value "Digital
+  # Library of the Caribbean." (the period is included in the MARC record)
+  # Guessing here based on something in the ESDN map.  --GG
+  intermediateProvider :class => DPLA::MAP::Agent do
+                       :each => record.field('marc:datafield')
+                                      .match_attribute(:tag, '830')
+                       :as interP do
+    providedLabel interP.field('marc:subfield')
+                        .match_attribute(:code, 'a')
+                        .select do |i|
+                          i.map(&:value)
+                           .include?('Digital Library of the Caribbean.')
+                        end
+  end
+  
+  isShownAt :class => DPLA::MAP::WebResource do
+            :each => record.field('marc:datafield')
+                           .match_attribute(:tag, '856')
+            :as => :URI do
+    uri URI.field('marc:subfield').match_attribute(:code, 'u')
+  end
+
+  preview :class => DPLA::MAP::WebResource do
+          :each => record.field('marc:datafield')
+                         .match_attribute(:tag, '992')
+            :as => :thumb do
+    uri thumb.field('marc:subfield').match_attribute(:code, 'a')
+  end
+
+  originalRecord :class => DPLA::MAP::WebResource do
+    uri record_uri
+  end
+
+  sourceResource :class => DPLA::MAP::SourceResource do
+
+    collection :class => DPLA::MAP::Collection, 
+               :each => record.field('marc:datafield')
+                              .match_attribute(:tag, '830')
+               :as => :coll do
+      title coll.field('marc:subfield').match_attribute(:code, 'a')
+    end
+
+    #don't know how to do these but am keeping placeholder
+    #contributor 
+
+    #creator 
+
+    date :class => DPLA::MAP::TimeSpan do
+         :each => record.field('marc:datafield')
+                        .match_attribute(:tag, '260')
+         :as => :date do
+      providedLabel date.field('marc:subfield').match_attribute(:code, 'c')
+    end
+
+    #description 
+
+    extent record.fields([('marc:datafield')
+                  .match_attribute(:tag, '300')
+                  .field('marc:subfield').match_attribute(:code, 'a')],
+                  [('marc:datafield').match_attribute(:tag, '300')
+                  .field('marc:subfield').match_attribute(:code, 'c')],
+                  [('marc:datafield').match_attribute(:tag, '340')
+                  .field('marc:subfield').match_attribute(:code, 'b')])
+    #dcformat 
+    
+    #genre 
+
+    #identifier 
+
+    #language 
+
+    #spatial 
+
+    publisher :class => DPLA::MAP::Agent, 
+              :each => record.field('marc:datafield')
+                             .match_attribute(:tag, '260')
+              :as => :pub do
+      providedLabel pub.field('marc:subfield').match_attribute(:code, 'b')
+    end
+    
+    # for relation below the mapping is to both 780$t and 787$t, not sure how
+    # to combine attribute mappings in an OR relationship
+    relation record.field('marc:datafield').match_attribute(:tag, '780')
+                   .field('marc:subfield').match_attribute(:code, 't')            
+                 
+    rights record.field('marc:datafield').match_attribute(:tag, '506')
+                   .field('marc:subfield').match_attribute(:code, 'a')
+
+    #subject 
+
+    #title 
+
+    #dctype
+  end
+end

--- a/heidrun/ufl_marc.rb
+++ b/heidrun/ufl_marc.rb
@@ -14,6 +14,11 @@ contributor_select = lambda { |df|
     !['aut', 'cre'].include?(subfield_e(df)))
 }
 
+creator_select = lambda { |df|
+  ['100', '110', '111', '700'].include?(df.tag) &&
+    ['joint author.', 'jt author'].include?(subfield_e(df))
+}
+
 
 Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MARCXMLParser) do
   provider :class => DPLA::MAP::Agent do
@@ -75,7 +80,15 @@ Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MARCXMLParser) do
       providedLabel contrib.field('marc:subfield')
     end
 
-    #creator 
+    # creator:
+    #   100, 110, 111, 700 when the relator term (subfield e) is
+    #   'joint author.' or 'jt author'
+    creator :class => DPLA::MAP::Agent,
+            :each => record.field('marc:datafield')
+                           .select(&creator_select),
+            :as => :cre do
+      providedLabel cre.field('marc:subfield')
+    end
 
     date :class => DPLA::MAP::TimeSpan,
          :each => record.field('marc:datafield')

--- a/heidrun/ufl_marc.rb
+++ b/heidrun/ufl_marc.rb
@@ -1,13 +1,13 @@
-Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MarcParser) do
+Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MARCXMLParser) do
 
   provider :class => DPLA::MAP::Agent do
     uri 'http://dp.la/api/contributor/ufl'
     label 'University of Florida Libraries'
   end
 
-  dataProvider :class => DPLA::MAP::Agent do
+  dataProvider :class => DPLA::MAP::Agent,
                :each => record.field('marc:datafield')
-                              .match_attribute(:tag, '535')
+                              .match_attribute(:tag, '535'),
                :as => :dataP do
     providedLabel dataP.field('marc:subfield').match_attribute(:code, 'a')
   end
@@ -15,10 +15,10 @@ Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MarcParser) do
   # Not sure how to limit this to only those fields with the value "Digital
   # Library of the Caribbean." (the period is included in the MARC record)
   # Guessing here based on something in the ESDN map.  --GG
-  intermediateProvider :class => DPLA::MAP::Agent do
+  intermediateProvider :class => DPLA::MAP::Agent,
                        :each => record.field('marc:datafield')
-                                      .match_attribute(:tag, '830')
-                       :as interP do
+                                      .match_attribute(:tag, '830'),
+                       :as => interP do
     providedLabel interP.field('marc:subfield')
                         .match_attribute(:code, 'a')
                         .select do |i|
@@ -27,17 +27,17 @@ Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MarcParser) do
                         end
   end
   
-  isShownAt :class => DPLA::MAP::WebResource do
+  isShownAt :class => DPLA::MAP::WebResource,
             :each => record.field('marc:datafield')
-                           .match_attribute(:tag, '856')
+                           .match_attribute(:tag, '856'),
             :as => :URI do
     uri URI.field('marc:subfield').match_attribute(:code, 'u')
   end
 
-  preview :class => DPLA::MAP::WebResource do
+  preview :class => DPLA::MAP::WebResource,
           :each => record.field('marc:datafield')
-                         .match_attribute(:tag, '992')
-            :as => :thumb do
+                         .match_attribute(:tag, '992'),
+          :as => :thumb do
     uri thumb.field('marc:subfield').match_attribute(:code, 'a')
   end
 
@@ -49,7 +49,7 @@ Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MarcParser) do
 
     collection :class => DPLA::MAP::Collection, 
                :each => record.field('marc:datafield')
-                              .match_attribute(:tag, '830')
+                              .match_attribute(:tag, '830'),
                :as => :coll do
       title coll.field('marc:subfield').match_attribute(:code, 'a')
     end
@@ -59,22 +59,24 @@ Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MarcParser) do
 
     #creator 
 
-    date :class => DPLA::MAP::TimeSpan do
+    date :class => DPLA::MAP::TimeSpan,
          :each => record.field('marc:datafield')
-                        .match_attribute(:tag, '260')
+                        .match_attribute(:tag, '260'),
          :as => :date do
       providedLabel date.field('marc:subfield').match_attribute(:code, 'c')
     end
 
     #description 
 
-    extent record.fields([('marc:datafield')
-                  .match_attribute(:tag, '300')
-                  .field('marc:subfield').match_attribute(:code, 'a')],
-                  [('marc:datafield').match_attribute(:tag, '300')
-                  .field('marc:subfield').match_attribute(:code, 'c')],
-                  [('marc:datafield').match_attribute(:tag, '340')
-                  .field('marc:subfield').match_attribute(:code, 'b')])
+    # FIXME:
+    # extent record.fields([('marc:datafield')
+    #               .match_attribute(:tag, '300')
+    #               .field('marc:subfield').match_attribute(:code, 'a')],
+    #               [('marc:datafield').match_attribute(:tag, '300')
+    #               .field('marc:subfield').match_attribute(:code, 'c')],
+    #               [('marc:datafield').match_attribute(:tag, '340')
+    #               .field('marc:subfield').match_attribute(:code, 'b')])
+
     #dcformat 
     
     #genre 
@@ -87,7 +89,7 @@ Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MarcParser) do
 
     publisher :class => DPLA::MAP::Agent, 
               :each => record.field('marc:datafield')
-                             .match_attribute(:tag, '260')
+                             .match_attribute(:tag, '260'),
               :as => :pub do
       providedLabel pub.field('marc:subfield').match_attribute(:code, 'b')
     end

--- a/heidrun/ufl_marc.rb
+++ b/heidrun/ufl_marc.rb
@@ -18,20 +18,20 @@ Krikri::Mapper.define(:ufl_marc, :parser => Krikri::MARCXMLParser) do
   intermediateProvider :class => DPLA::MAP::Agent,
                        :each => record.field('marc:datafield')
                                       .match_attribute(:tag, '830'),
-                       :as => interP do
+                       :as => :interP do
+    # FIXME:  Produces multiple providedLabels where the value is 'false'
     providedLabel interP.field('marc:subfield')
                         .match_attribute(:code, 'a')
-                        .select do |i|
-                          i.map(&:value)
-                           .include?('Digital Library of the Caribbean.')
+                        .select do |code_a|
+                          code_a.include?('Digital Library of the Caribbean.')
                         end
   end
   
   isShownAt :class => DPLA::MAP::WebResource,
             :each => record.field('marc:datafield')
                            .match_attribute(:tag, '856'),
-            :as => :URI do
-    uri URI.field('marc:subfield').match_attribute(:code, 'u')
+            :as => :the_uri do
+    uri the_uri.field('marc:subfield').match_attribute(:code, 'u')
   end
 
   preview :class => DPLA::MAP::WebResource,


### PR DESCRIPTION
NOT FOR MERGE

Please see https://github.com/dpla/heidrun-mappings/commit/60fd80aad5a57302ca606cef9e02d65ee00a9468 and the comments around the genre mapping in `ufl_marc.rb`, noting the error that's returned about ['Newspapers'] not being a valid datatype, and the commented out attempts that do not result in errors.

Regarding the added `MappingTools::MARC` module: the generation of a genre value is too complex to be put inside a single large method chain with large lambdas, and it's also hard to imagine another way to analyze multiple sibling elements of the root element; thus the attempt to create a separate module, which could also be shared with the other two upcoming MARC mappings (GPO and UIUC).
