### PR TITLE
Revert "Use OAI setSpec element properly (DLG, ESDN, NCDHC, UW)"

### DIFF
--- a/heidrun/dlg_dc.rb
+++ b/heidrun/dlg_dc.rb
@@ -31,7 +31,7 @@ Krikri::Mapper.define(:dlg_dc, :parser => Krikri::OaiDcParser) do
     # TODO: Crosswalk says to take collection from OAI set name/description,
     # but we need to be able harvest set titles and populate them somewhere.
     # This will just pull back the setSpec code for now.
-    collection :class => DPLA::MAP::Collection, :each => header.field('xmlns:setSpec'), :as => :coll do
+    collection :class => DPLA::MAP::Collection, :each => record.field('xmlns:header', 'xmlns:setSpec'), :as => :coll do
       title coll
     end
 

--- a/heidrun/esdn_mods.rb
+++ b/heidrun/esdn_mods.rb
@@ -33,7 +33,9 @@ Krikri::Mapper.define(:esdn_mods, :parser => Krikri::ModsParser) do
     # the metadata required for collections. This just grabs the set's
     # identifier from the OAI-PMH setSpec in the record header.
     collection :class => DPLA::MAP::Collection,
-               :each => header.field('xmlns:setSpec'),
+               # setSpec is set_spec due to a bug in Krikri;
+               # revert this after the patch is deployed
+               :each => header.field('xmlns:set_spec'),
                :as => :coll do
       title coll
     end

--- a/heidrun/ncdhc.rb
+++ b/heidrun/ncdhc.rb
@@ -26,7 +26,7 @@ Krikri::Mapper.define(:ncdhc, :parser => Krikri::ModsParser) do
   sourceResource :class => DPLA::MAP::SourceResource do
     
     collection :class => DPLA::MAP::Collection, 
-               :each => header.field('xmlns:setSpec'),
+               :each => header.field('xmlns:set_spec'), 
                :as => :coll do
       title coll
     end

--- a/heidrun/uw_qdc.rb
+++ b/heidrun/uw_qdc.rb
@@ -32,7 +32,9 @@ Krikri::Mapper.define(:uw_qdc,
 
   sourceResource :class => DPLA::MAP::SourceResource do
     collection :class => DPLA::MAP::Collection,
-               :each => header.field('xmlns:setSpec'),
+               # setSpec is set_spec due to a bug in Krikri;
+               # revert this after the patch is deployed
+               :each => record.fields('xmlns:header', 'xmlns:set_spec'), 
                :as => :coll do
       title coll
     end


### PR DESCRIPTION
This reverts commit f22858ae246a29c74d7c126aa4a648d4602e6cf5.

The existing original records for some of these collections were
harvested with the old harvester's `set_spec` typo. The mappings need to
be adjusted as the relevant partners are reharvested.
