### PR TITLE
Mappings for Getty and MWDL

### DIFF
--- a/heidrun/getty.rb
+++ b/heidrun/getty.rb
@@ -1,0 +1,119 @@
+DATA_PROVIDER_MAP = {
+  'GETTY_ROSETTA' => 'Getty Research Institute',
+  'GETTY_OCP' => 'Getty Research Institute'
+}
+
+build_url = lambda do |p|
+  source = p.root[Krikri::PrimoParser.record('control', 'sourceid').join('/')]
+           .first.value
+  id = p.root[Krikri::PrimoParser.record('control', 'recordid').join('/')]
+       .first.value
+
+  base_url = 'http://primo.getty.edu/primo_library/libweb/action/dlDisplay.do'
+
+  case source
+  when 'GETTY_ROSETTA'
+    "#{base_url}?vid=GRI&afterPDS=true&institution=01GRI&docId=#{id}"
+  when 'GETTY_OCP'
+    "#{base_url}?vid=GRI-OCP&afterPDS=true&institution=01GRI&docId=#{id}"
+  end
+end
+
+Krikri::Mapper.define(:getty,
+                      parser: Krikri::PrimoParser) do
+  provider class: DPLA::MAP::Agent do
+    uri 'http://dp.la/api/contributor/getty'
+    label 'J. Paul Getty Trust'
+  end
+
+  dataProvider class: DPLA::MAP::Agent,
+               each: record.field(*Krikri::PrimoParser.record('control',
+                                                              'sourceid'))
+                      .map { |i| DATA_PROVIDER_MAP.fetch(i.value, i.value) }
+                      .first_value,
+               as: :provider do
+    label provider
+  end
+
+  isShownAt class: DPLA::MAP::WebResource do
+    uri build_url
+  end
+
+  preview class: DPLA::MAP::WebResource do
+    uri record.field('sear:LINKS', 'sear:thumbnail')
+  end
+
+  sourceResource class: DPLA::MAP::SourceResource do
+    # TODO: Enrichment needed to split title fields on semicolons
+    title record.fields(Krikri::PrimoParser.display('title'),
+                        Krikri::PrimoParser.display('lds03'))
+
+    collection class: DPLA::MAP::Collection,
+               each: record.fields(Krikri::PrimoParser.display('lds34'),
+                                   Krikri::PrimoParser.display('lds43')),
+               as: :coll do
+      title coll
+    end
+
+    # TODO: Enrichment needed to split contributor providedLabel on semicolons
+    contributor class: DPLA::MAP::Agent,
+                each: record.field(*Krikri::PrimoParser.display('contributor')),
+                as: :contrib do
+      providedLabel contrib
+    end
+
+    creator class: DPLA::MAP::Agent,
+            each: record.field(*Krikri::PrimoParser.display('creator')),
+            as: :creator do
+      providedLabel creator
+    end
+
+    date class: DPLA::MAP::TimeSpan,
+         each: record.field(*Krikri::PrimoParser.display('creationdate'))
+           .first_value,
+         as: :created do
+      providedLabel created
+    end
+
+    description record.fields(Krikri::PrimoParser.display('lds04'),
+                              Krikri::PrimoParser.display('lds28'),
+                              Krikri::PrimoParser.display('rights'))
+
+    extent record.field(*Krikri::PrimoParser.display('format'))
+
+    dcformat record.field(*Krikri::PrimoParser.display('lds09'))
+
+    # TODO: Enrichment needed here to map (e.g.) 'Still image' to 'image'
+    genre record.field(*Krikri::PrimoParser.display('lds26'))
+    dctype record.field(*Krikri::PrimoParser.display('lds26'))
+
+    # TODO: Enrichment needed to split identifier on semicolons
+    identifier record.field(*Krikri::PrimoParser.display('lds14'))
+
+    language class: DPLA::MAP::Controlled::Language,
+             each: record.field(*Krikri::PrimoParser.display('language')),
+             as: :lang do
+      providedLabel lang
+    end
+
+    # TODO: Enrichment needed to split publisher providedLabel on semicolons
+    publisher class: DPLA::MAP::Agent,
+              each: record.field(*Krikri::PrimoParser.display('publisher')),
+              as: :publisher do
+      providedLabel publisher
+    end
+
+    # TODO: Enrichment needed to split relation on semicolons
+    relation record.fields(['sear:LINKS', 'sear:lln04'],
+                           Krikri::PrimoParser.display('ispartof'))
+
+    rights record.field(*Krikri::PrimoParser.display('lds27'))
+
+    # TODO: Enrichment needed to split subject providedLabel on semicolons
+    subject class: DPLA::MAP::Concept,
+            each: record.field(*Krikri::PrimoParser.display('subject')),
+            as: :subject do
+      providedLabel subject
+    end
+  end
+end

--- a/heidrun/mwdl.rb
+++ b/heidrun/mwdl.rb
@@ -1,0 +1,124 @@
+build_url = lambda do |p|
+  id = p.root[Krikri::PrimoParser.record('control', 'recordid').join('/')]
+       .first.value
+  "http://utah-primoprod.hosted.exlibrisgroup.com/primo_library/libweb/action/dlDisplay.do?vid=MWDL&afterPDS=true&docId=#{id}"
+end
+
+build_intermediate_provider = lambda do |p|
+  srcid = p[Krikri::PrimoParser.record('control', 'sourceid').join('/')]
+             .first.value
+  lsr02 = p[Krikri::PrimoParser.search('lsr02').join('/')]
+          .first.value
+
+  if srcid == 'digcoll_msl_38' && lsr02 == '38'
+    'Montana Memory Project'
+  elsif srcid == 'digcoll_asl_31' && lsr02 == '31'
+    'Arizona Memory Project'
+  end
+end
+
+Krikri::Mapper.define(:mwdl, parser: Krikri::PrimoParser) do
+  provider class: DPLA::MAP::Agent do
+    uri 'http://dp.la/api/contributor/mwdl'
+    label 'Mountain West Digital Library'
+  end
+
+  dataProvider class: DPLA::MAP::Agent do
+    label record.field(*Krikri::PrimoParser.display('lds03'))
+  end
+
+  intermediateProvider class: DPLA::MAP::Agent,
+                       each: record.map(&build_intermediate_provider)
+                         .first_value,
+                       as: :provider do
+    label provider
+  end
+
+  isShownAt class: DPLA::MAP::WebResource do
+    uri build_url
+  end
+
+  preview class: DPLA::MAP::WebResource do
+    uri record.field('sear:LINKS', 'sear:thumbnail')
+  end
+
+  sourceResource class: DPLA::MAP::SourceResource do
+    collection class: DPLA::MAP::Collection,
+               each: record.field(*Krikri::PrimoParser.search('lsr13')),
+               as: :coll do
+      title coll
+    end
+
+    creator class: DPLA::MAP::Agent,
+            each: record.field(*Krikri::PrimoParser.display('creator')),
+            as: :creator do
+      providedLabel creator
+    end
+
+    ## TODO: Need an enrichment to turn these into:
+    #
+    #   "begin": "1930",
+    #   "displayDate": "1930-1946"
+    #   "end": "1946"
+    #
+    # Currently they are semicolon delimiter lists of years like:
+    #  1930; 1931; 1932; 1933; 1934; 1935; 1936; 1937; 1938; 1939; 1940; 1941;
+    #  1942; 1943; 1944; 1945; 1946"
+    date class: DPLA::MAP::TimeSpan,
+         each: record.field(*Krikri::PrimoParser.search('creationdate')),
+         as: :created do
+      providedLabel created
+    end
+
+    description record.field(*Krikri::PrimoParser.search('description'))
+
+    extent record.field(*Krikri::PrimoParser.display('lds05'))
+
+    identifier record.field(*Krikri::PrimoParser.record('control', 'recordid'))
+
+    language class: DPLA::MAP::Controlled::Language do
+      prefLabel record.field(*Krikri::PrimoParser.record('facets', 'language'))
+    end
+
+    spatial class: DPLA::MAP::Place,
+            each: record.field(*Krikri::PrimoParser.display('lds08')),
+            as: :place do
+      providedLabel place
+    end
+
+    relation record.field(*Krikri::PrimoParser.display('relation'))
+
+    rights record.field(*Krikri::PrimoParser.display('rights'))
+
+    # TODO: Enrichment needed to split subject providedLabel on semicolons
+    subject class: DPLA::MAP::Concept,
+            each: record.field(*Krikri::PrimoParser.display('subject')),
+            as: :subject do
+      providedLabel subject
+    end
+
+    # TODO: Need an enrichment to parse these?  Currently may be semicolons, and
+    # may appear as follows:
+    #
+    #  [{... "@type"=>"edm:TimeSpan", "providedLabel"=>"1930-1939"},
+    #   {... "@type"=>"edm:TimeSpan", "providedLabel"=>"1940-1949"},
+    #   {... "@type"=>"edm:TimeSpan", "providedLabel"=>"20th century"}]
+    #
+    # but should have begin and end dates?
+    temporal class: DPLA::MAP::TimeSpan,
+             each: record.field(*Krikri::PrimoParser.display('lds09')),
+             as: :date_string do
+      providedLabel date_string
+    end
+
+    # TODO: Enrichment needed to split title on semicolons
+    title record.fields(Krikri::PrimoParser.display('title'),
+                        Krikri::PrimoParser.display('lds10'))
+
+    dctype record.field(*Krikri::PrimoParser.record('facets', 'rsrctype'))
+
+    # TODO: Enrichment needed to split dcformat on semicolons
+    dcformat record.field(*Krikri::PrimoParser.display('format'))
+              .reject { |i| i.value.downcase == 'unknown' }
+  end
+end


### PR DESCRIPTION
Here's a first attempt at mappings for Getty and MWDL.  Some general remarks:
- There's a lot of semicolon delimited fields, so I'm doing a lot of `.map { |v| v.value.split(';').map(&:strip) }.flatten` to deal with those.
  
  Does that seem like a sign that I should really be using an enrichment?  Or would it be worth defining a helper (on ValueArray, or a MappingTool?) for this?
- I've marked the places that I think might need enrichments with `TODO` entries.  Feedback on whether I've got that right would be appreciated :)
- The rule for working out the MWDL data provider is tricky, as it's conditional on the value of two different fields, and may be `nil` if neither field matches.  Originally I just had:
  
  ```
  intermediateProvider :class ... do
    label build_intermediate_provider
  end
  ```
  
  but when `build_intermediate_provider` would return `nil`, my JSON-LD output would have an `intermediateProvider` entry with an `@id` and `@type`, but no `name`, and that didn't seem right.
  
  I got around that using the `.map` call you can see in the code, but I wasn't sure if there was a better way to do this.
