### PR TITLE
Update `set_spec` to correct OAI form `setSpec`

### DIFF
--- a/heidrun/esdn_mods.rb
+++ b/heidrun/esdn_mods.rb
@@ -33,9 +33,7 @@ Krikri::Mapper.define(:esdn_mods, :parser => Krikri::ModsParser) do
     # the metadata required for collections. This just grabs the set's
     # identifier from the OAI-PMH setSpec in the record header.
     collection :class => DPLA::MAP::Collection,
-               # setSpec is set_spec due to a bug in Krikri;
-               # revert this after the patch is deployed
-               :each => header.field('xmlns:set_spec'),
+               :each => header.field('xmlns:setSpec'),
                :as => :coll do
       title coll
     end

--- a/heidrun/ncdhc.rb
+++ b/heidrun/ncdhc.rb
@@ -26,7 +26,7 @@ Krikri::Mapper.define(:ncdhc, :parser => Krikri::ModsParser) do
   sourceResource :class => DPLA::MAP::SourceResource do
     
     collection :class => DPLA::MAP::Collection, 
-               :each => header.field('xmlns:set_spec'), 
+               :each => header.field('xmlns:setSpec'), 
                :as => :coll do
       title coll
     end

--- a/heidrun/uw_qdc.rb
+++ b/heidrun/uw_qdc.rb
@@ -32,9 +32,7 @@ Krikri::Mapper.define(:uw_qdc,
 
   sourceResource :class => DPLA::MAP::SourceResource do
     collection :class => DPLA::MAP::Collection,
-               # setSpec is set_spec due to a bug in Krikri;
-               # revert this after the patch is deployed
-               :each => header.field('xmlns:set_spec'), 
+               :each => header.field('xmlns:setSpec'), 
                :as => :coll do
       title coll
     end


### PR DESCRIPTION
An issue in Krikri had us converting OAI `setSpec` headers to `set_spec`
by mistake. This is now patched, and for all future harvests we want to
map from `setSpec`.

The relevant
[diff](https://github.com/dpla/KriKri/commit/fe57738647a0b060bd47d0bfdf0f67e50c2b9238#diff-8d0c691718e8aa47ff13511391860fb4)
is the switch to Ruby OAI's `#_source` method.
