### PR TITLE
Smithsonian: use Krikri::XmlParser to remove SI-specific parser

### DIFF
--- a/heidrun/smithsonian.rb
+++ b/heidrun/smithsonian.rb
@@ -262,7 +262,8 @@ spatial_map = lambda do |record|
 end
 
 Krikri::Mapper.define(:smithsonian,
-                      :parser => Krikri::SmithsonianParser) do
+                      :parser => Krikri::XmlParser,
+                      :parser_args => '//doc') do
   # edm:provider
   #   Smithsonian Institution
   provider :class => DPLA::MAP::Agent do


### PR DESCRIPTION
See dpla/Krikri#225, which we can close if everyone's happy with this.
