### PR TITLE
Handle empty date strings in NARA JSON

### DIFF
--- a/heidrun/nara_json.rb
+++ b/heidrun/nara_json.rb
@@ -65,7 +65,7 @@ format_date = lambda do |date|
               date['month'].values.first, 
               date['day'].values.first]
              .compact.map { |e| "%02d" % e }.join '-'
-  return if date_str.empty?
+  return '' if date_str.empty?
   qualifier = date['dateQualifier'].field('termName').values.first
 
   return date_str if qualifier.nil?


### PR DESCRIPTION
The date formatter can sometimes receive a node that it won't be able to
extract a date from, in this case, we had been returning `nil`. Doing so
crashes the mapper for the record. We instead return an empty string.
