### PR TITLE
Fixup description mapping and formatting/style issues

### DIFF
--- a/heidrun/cdl.rb
+++ b/heidrun/cdl.rb
@@ -7,12 +7,8 @@
 #
 #  e.g.
 #   https://thumbnails.calisphere.org/clip/1536:1024/39e015bc8fd770a69775811891784282
-cdl_preview = lambda do |r|
-  base_url = 'https://thumbnails.calisphere.org/clip/'
-  md5_hash = r['reference_image_md5'].first ? r['reference_image_md5'].first.value : nil
-  image_url = nil
-
-  image_url = base_url + '150x150/' + md5_hash unless md5_hash.nil?
+def cdl_preview(md5)
+  image_url = md5 && ("https://thumbnails.calisphere.org/clip/150x150/#{md5}")
   image_url
 end
 
@@ -126,6 +122,8 @@ Krikri::Mapper.define(:cdl, parser: Krikri::JsonParser) do
   end
 
   preview class: DPLA::MAP::WebResource do
-    uri record.map(&cdl_preview).flatten
+    uri record.field('reference_image_md5').first_value.map { |md5|
+      cdl_preview(md5.value)
+    }
   end
 end

--- a/heidrun/cdl.rb
+++ b/heidrun/cdl.rb
@@ -12,9 +12,7 @@ cdl_preview = lambda do |r|
   md5_hash = r['reference_image_md5'].first ? r['reference_image_md5'].first.value : nil
   image_url = nil
 
-  if !md5_hash.nil?
-    image_url = base_url + '150x150/' + md5_hash
-  end
+  image_url = base_url + '150x150/' + md5_hash unless md5_hash.nil?
   image_url
 end
 
@@ -35,7 +33,7 @@ end
 
 # California Digital Library Mapping
 #
-Krikri::Mapper.define(:cdl, parser: Krikri::JsonParser ) do
+Krikri::Mapper.define(:cdl, parser: Krikri::JsonParser) do
   provider class: DPLA::MAP::Agent do
     uri 'http://dp.la/api/contributor/cdl'
     label 'California Digital Library'
@@ -45,34 +43,34 @@ Krikri::Mapper.define(:cdl, parser: Krikri::JsonParser ) do
     uri record_uri
   end
 
-  sourceResource :class => DPLA::MAP::SourceResource do
+  sourceResource class: DPLA::MAP::SourceResource do
     alternative record.field('alternative_title_ss')
 
-    collection  :class => DPLA::MAP::Collection,
-                :each => record.field('collection_name'),
-                :as => :coll do
+    collection  class: DPLA::MAP::Collection,
+                each: record.field('collection_name'),
+                as: :coll do
       title coll
     end
 
-    contributor :class => DPLA::MAP::Agent,
-                :each => record.field('contributor_ss'),
-                :as => :contrib do
+    contributor class: DPLA::MAP::Agent,
+                each: record.field('contributor_ss'),
+                as: :contrib do
       providedLabel contrib
     end
 
-    creator :class => DPLA::MAP::Agent,
-            :each => record.field('creator_ss'),
-            :as => :creator do
+    creator class: DPLA::MAP::Agent,
+            each: record.field('creator_ss'),
+            as: :creator do
       providedLabel creator
     end
 
-    date  :class => DPLA::MAP::TimeSpan,
-          :each => record.field('date_ss'),
-          :as => :created do
+    date  class: DPLA::MAP::TimeSpan,
+          each: record.field('date_ss'),
+          as: :created do
       providedLabel created
     end
 
-    description record.field('description_ss')
+    description record.field('description')
 
     extent record.field('extent_ss')
 
@@ -82,15 +80,15 @@ Krikri::Mapper.define(:cdl, parser: Krikri::JsonParser ) do
 
     identifier record.field('identifier_ss')
 
-    language  :class => DPLA::MAP::Controlled::Language,
-              :each => record.field('language_ss'),
-              :as => :lang do
+    language  class: DPLA::MAP::Controlled::Language,
+              each: record.field('language_ss'),
+              as: :lang do
       prefLabel lang
     end
 
-    spatial :class => DPLA::MAP::Place,
-            :each => record.field('coverage_ss'),
-            :as => :place do
+    spatial class: DPLA::MAP::Place,
+            each: record.field('coverage_ss'),
+            as: :place do
       providedLabel place
     end
 
@@ -102,15 +100,15 @@ Krikri::Mapper.define(:cdl, parser: Krikri::JsonParser ) do
 
     rightsHolder record.field('rights_holder_ss')
 
-    subject :class => DPLA::MAP::Concept,
-            :each => record.field('subject_ss'),
-            :as => :subject do
+    subject class: DPLA::MAP::Concept,
+            each: record.field('subject_ss'),
+            as: :subject do
       providedLabel subject
     end
 
-    temporal :class => DPLA::MAP::TimeSpan,
-             :each => record.field('temporal_ss'),
-             :as => :date_string do
+    temporal class: DPLA::MAP::TimeSpan,
+             each: record.field('temporal_ss'),
+             as: :date_string do
       providedLabel date_string
     end
 
@@ -119,15 +117,15 @@ Krikri::Mapper.define(:cdl, parser: Krikri::JsonParser ) do
     dctype record.field('type_ss')
   end
 
-  dataProvider :class => DPLA::MAP::Agent do
-    providedLabel record.map( &cdl_provider ).flatten
+  dataProvider class: DPLA::MAP::Agent do
+    providedLabel record.map(&cdl_provider).flatten
   end
 
-  isShownAt :class => DPLA::MAP::WebResource do
+  isShownAt class: DPLA::MAP::WebResource do
     uri record.field('url_item')
   end
 
-  preview :class => DPLA::MAP::WebResource do
-    uri record.map( &cdl_preview ).flatten
+  preview class: DPLA::MAP::WebResource do
+    uri record.map(&cdl_preview).flatten
   end
 end


### PR DESCRIPTION
Maps `description` rather than `description_ss` and cleaned up formatting with rubocop. 
